### PR TITLE
chore: adjust compat entry for Nemo and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraicSolving"
 uuid = "66b61cbe-0446-4d5d-9090-1ff510639f9d"
 authors = ["ederc <ederc@mathematik.uni-kl.de>", "Mohab Safey El Din <Mohab.Safey@lip6.fr", "Rafael Mohr <rafael.mohr@lip6.fr>"]
-version = "0.4.7"
+version = "0.4.8"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -17,7 +17,7 @@ msolve_jll = "6d01cc9a-e8f6-580e-8c54-544227e08205"
 
 [compat]
 LoopVectorization = "0.12"
-Nemo = "0.35.1, 0.36, 0.37, 0.38, 0.39, 0.40"
+Nemo = "0.35.1, 0.36, 0.37, 0.38, 0.39, 0.40, 0.41"
 StaticArrays = "1"
 julia = "1.6"
 LinearAlgebra = "1.6"


### PR DESCRIPTION
We are already working on the next round of renamings in Nemo. Again, they don't matter at all for AlgebraicSolving, but the compat needs to be adjusted for Oscar to work.
It would be great, if you could release a new version with this. Thanks!