### PR TITLE
Fix bug on variables permutation, when additional variables

### DIFF
--- a/src/algorithms/solvers.jl
+++ b/src/algorithms/solvers.jl
@@ -142,8 +142,8 @@ function _core_msolve(
 
     jl_vnames = Base.unsafe_wrap(Array, res_vnames[], jl_rp_nr_vars)
     vsymbols  = [Symbol(unsafe_string(jl_vnames[i])) for i in 1:jl_rp_nr_vars]
-    #= get possible variable permutation =#
-    perm      = sortperm(vsymbols)
+    #= get possible variable permutation, ignoring additional variables=#
+    perm      = sortperm(vsymbols[1:1:nr_vars])
 
     rat_param = _get_rational_parametrization(jl_ld, jl_len,
                                               jl_cf, jl_cf_lf, jl_rp_nr_vars)

--- a/src/algorithms/solvers.jl
+++ b/src/algorithms/solvers.jl
@@ -143,7 +143,7 @@ function _core_msolve(
     jl_vnames = Base.unsafe_wrap(Array, res_vnames[], jl_rp_nr_vars)
     vsymbols  = [Symbol(unsafe_string(jl_vnames[i])) for i in 1:jl_rp_nr_vars]
     #= get possible variable permutation, ignoring additional variables=#
-    perm      = sortperm(vsymbols[1:1:nr_vars])
+    perm      = sortperm(vsymbols[1:nr_vars])
 
     rat_param = _get_rational_parametrization(jl_ld, jl_len,
                                               jl_cf, jl_cf_lf, jl_rp_nr_vars)

--- a/test/algorithms/solvers.jl
+++ b/test/algorithms/solvers.jl
@@ -59,4 +59,7 @@
         [1, 0]
             ]
     @test sols == real_solutions(I)
+
+    I = Ideal([x^2-1, y^2])
+    @test sols == real_solutions(I)
 end

--- a/test/algorithms/solvers.jl
+++ b/test/algorithms/solvers.jl
@@ -58,8 +58,8 @@
         [-1, 0],
         [1, 0]
             ]
-    @test sols == real_solutions(I)
+    @test sort(sols) == sort(real_solutions(I))
 
     I = Ideal([x^2-1, y^2])
-    @test sols == real_solutions(I)
+    @test sort(sols) == sort(real_solutions(I))
 end


### PR DESCRIPTION
Reordering the variables in the output of msolve moves additional variables from the end to the beginning, while we want to ignore their values when isolating. 

This caused an "index out of range" when pairing the isolated values and the corresponding variables, because we do not isolate values of additional variables. This happens for the system [x^2-1,y^2] for example, so I added it to the tests.

This is my first pull request ever, I hope I've done things right.