### PR TITLE
Fix bug in variable permutation

### DIFF
--- a/src/algorithms/solvers.jl
+++ b/src/algorithms/solvers.jl
@@ -147,7 +147,7 @@ function _core_msolve(
     jl_vnames = Base.unsafe_wrap(Array, res_vnames[], jl_rp_nr_vars)
     vsymbols  = [Symbol(unsafe_string(jl_vnames[i])) for i in 1:jl_rp_nr_vars]
     #= get possible variable permutation, ignoring additional variables=#
-    perm      = sortperm(vsymbols[1:nr_vars])
+    perm      = findfirst.(isequal.(R.S), Ref(vsymbols))
 
     rat_param = _get_rational_parametrization(jl_ld, jl_len,
                                               jl_cf, jl_cf_lf, jl_rp_nr_vars)


### PR DESCRIPTION
When msolve permute the variables or add new ones, re-order the real solutions in the initial variable ordering, and remove the entries corresponding to the additional variables.

The previous version was ordering in the alphabetic order not working e.g. if the input variables were [:x1, :x2, :x3, :x4, :B, :A], it was reordering the roots as [:A, :B, :x1, :x2, :x3, :x4].