### PR TITLE
Handle zero ideal cases

### DIFF
--- a/src/algorithms/groebner-bases.jl
+++ b/src/algorithms/groebner-bases.jl
@@ -152,7 +152,7 @@ function _core_groebner_basis(
     F = I.gens
 
     if iszero(F)
-        I.gb[eliminate] = QQMPolyRingElem[]
+        I.gb[eliminate] = length(F)==0 ? F : F[1:1]
         return I.gb[eliminate]
     end
 
@@ -205,6 +205,11 @@ function _core_groebner_basis(
             cglobal(:jl_malloc), gb_ld, gb_len, gb_exp, gb_cf, lens, exps, cfs,
             field_char, mon_order, elim_block_size, nr_vars, nr_gens, initial_hts,
             nr_thrds, max_nr_pairs, 0, la_option, reduce_gb, 0, info_level)
+    end
+
+    if nr_terms == 0
+        I.gb[eliminate] = [R(0)]
+        return I.gb[eliminate]
     end
 
     # convert to julia array, also give memory management to julia

--- a/src/algorithms/groebner-bases.jl
+++ b/src/algorithms/groebner-bases.jl
@@ -150,12 +150,13 @@ function _core_groebner_basis(
         )
 
     F = I.gens
-    R = first(F).parent
 
-    if F == repeat([R(0)], length(F))
-        I.gb[eliminate] = F
-        return F
+    if iszero(F)
+        I.gb[eliminate] = QQMPolyRingElem[]
+        return I.gb[eliminate]
     end
+
+    R = first(F).parent
     nr_vars     = nvars(R)
     nr_gens     = length(F)
     field_char  = Int(characteristic(R))
@@ -214,7 +215,7 @@ function _core_groebner_basis(
     #  coefficient handling depending on field characteristic
     if field_char == 0
         ptr     = reinterpret(Ptr{BigInt}, gb_cf[])
-        jl_cf   = [QQFieldElem(unsafe_load(ptr, i)) for i in 1:nr_terms]
+        jl_cf   = QQFieldElem[QQFieldElem(unsafe_load(ptr, i)) for i in 1:nr_terms]
     else
         ptr     = reinterpret(Ptr{Int32}, gb_cf[])
         jl_cf   = Base.unsafe_wrap(Array, ptr, nr_terms)


### PR DESCRIPTION
Handle the cases where a GB of the zero ideal is output. More precisely when
* the input polynomials array is empty or contains only zeros;
* the elimination ideal is the zero ideal.

This assumes the convention that the GB of the zero ideal is the empty set, following Cox, Little & O'Shea.