### PR TITLE
Bump Nemo compat to incldue 0.47

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraicSolving"
 uuid = "66b61cbe-0446-4d5d-9090-1ff510639f9d"
 authors = ["ederc <ederc@mathematik.uni-kl.de>", "Mohab Safey El Din <Mohab.Safey@lip6.fr", "Rafael Mohr <rafael.mohr@lip6.fr>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -18,7 +18,7 @@ msolve_jll = "6d01cc9a-e8f6-580e-8c54-544227e08205"
 LinearAlgebra = "1.6"
 Logging = "1.6"
 Markdown = "1.6"
-Nemo = "0.43, 0.44, 0.45, 0.46"
+Nemo = "0.43, 0.44, 0.45, 0.46, 0.47"
 Printf = "1.6"
 Random = "1.6"
 StaticArrays = "1"


### PR DESCRIPTION
Could we get a release with this?
And if https://github.com/oscar-system/Oscar.jl/pull/3987 is expected to need another week or so, it would be great, if you could release a 0.5.x that is compatible with Nemo 0.47 as well, so that we can start work on bringing the new Nemo to Oscar.