### PR TITLE
Revert "Faster nemo interface"

### DIFF
--- a/src/interfaces/nemo.jl
+++ b/src/interfaces/nemo.jl
@@ -1,21 +1,3 @@
-function _resize_ff!(a::FqMPolyRingElem, n::Int)
-    if a.data isa Generic.MPoly
-        fit!(a, n)
-    elseif a.data isa fqPolyRepMPolyRingElem
-        ccall((:fq_nmod_mpoly_resize, Nemo.libflint), Nothing,
-            (Ref{fqPolyRepMPolyRingElem}, Int, Ref{fqPolyRepMPolyRing}), a.data,
-            n, a.parent.data)
-    else
-        @assert a.data isa Nemo.fpMPolyRingElem
-        ccall((:nmod_mpoly_resize, Nemo.libflint), Nothing,
-            (Ref{fpMPolyRingElem}, Int, Ref{fpMPolyRing}), a.data, n,
-            a.parent.data)
-     end
-end
-
-function _resize_qq!(a::QQMPolyRingElem, n::Int)
-    ccall((:fmpq_mpoly_resize, Nemo.libflint), Cvoid, (Ref{QQMPolyRingElem}, Int, Ref{QQMPolyRing}), a, n, parent(a))
-end
 
 @doc Markdown.doc"""
     _convert_to_msolve(
@@ -111,13 +93,14 @@ function _convert_finite_field_array_to_abstract_algebra(
     nr_vars = nvars(R)
     CR      = coefficient_ring(R)
 
-    len = 0
-    ctr = 0
+    basis = (typeof(R(0)))[]
+    #= basis = Vector{MPolyRingElem}(undef, bld) =#
+
+    len   = 0
 
     if eliminate > 0
         z = zeros(Int, eliminate)
     end
-    g = [zero(R) for j in 1:nr_gens]
     for i in 1:nr_gens
         #= check if element is part of the eliminated basis =#
         if eliminate > 0
@@ -127,21 +110,18 @@ function _convert_finite_field_array_to_abstract_algebra(
             end
         end
         if bcf[len+1] == 0
-            g[i] = R(0)
+            push!(basis, R(0))
         else
-            _resize_ff!(g[i], Int(blen[i]))
+            g  = MPolyBuildCtx(R)
             for j in 1:blen[i]
-                Nemo.setcoeff!(g[i], j, CR(bcf[len+j]))
+                push_term!(g, CR(bcf[len+j]),
+                           convert(Vector{Int}, bexp[(len+j-1)*nr_vars+1:(len+j)*nr_vars]))
             end
-            for j in 1:blen[i]
-                Nemo.set_exponent_vector!(g[i], j, convert(Vector{Int}, bexp[(len+j-1)*nr_vars+1:(len+j)*nr_vars]))
-            end
+            push!(basis, finish(g))
         end
-        ctr += 1
         len +=  blen[i]
     end
-    basis = g[1:ctr]
-    sort_terms!.(basis)
+
     return basis
 end
 
@@ -166,32 +146,32 @@ function _convert_rational_array_to_abstract_algebra(
     nr_vars = nvars(R)
     CR      = coefficient_ring(R)
 
+    basis = (typeof(R(0)))[]
+
     len   = 0
 
-    g = [zero(R) for j in 1:nr_gens]
     for i in 1:nr_gens
         if bcf[len+1] == 0
-            g[i] = R(0)
+            push!(basis, R(0))
         else
-            _resize_qq!(g[i], Int(blen[i]))
+            g  = MPolyBuildCtx(R)
             lc = bcf[len+1]
 
             if normalize && lc != 1
                 for j in 1:blen[i]
-                    Nemo.setcoeff!(g[i], j, bcf[len+j]/lc)
+                    push_term!(g, bcf[len+j]/lc,
+                               convert(Vector{Int}, bexp[(len+j-1)*nr_vars+1:(len+j)*nr_vars]))
                 end
             else
                 for j in 1:blen[i]
-                    Nemo.setcoeff!(g[i], j, bcf[len+j])
+                    push_term!(g, bcf[len+j],
+                               convert(Vector{Int}, bexp[(len+j-1)*nr_vars+1:(len+j)*nr_vars]))
                 end
             end
-            for j in 1:blen[i]
-                Nemo.set_exponent_vector!(g[i], j, convert(Vector{Int}, bexp[(len+j-1)*nr_vars+1:(len+j)*nr_vars]))
-            end
+            push!(basis, finish(g))
         end
         len +=  blen[i]
     end
 
-    sort_terms!.(g)
-    return g
+    return basis
 end

--- a/test/interfaces/nemo.jl
+++ b/test/interfaces/nemo.jl
@@ -9,12 +9,13 @@
     cmp = (Int32[1], BigInt[1], Int32[1, 0], 1) 
     @test AlgebraicSolving._convert_to_msolve(I.gens) == cmp
     for _GF in [GF, AlgebraicSolving.Nemo.Native.GF]
-        R, (x,y,z) = polynomial_ring(GF(2147483659),["x","y","z"], internal_ordering=:degrevlex)
+        R, (x,y,z) = polynomial_ring(_GF(2147483659),["x","y","z"], internal_ordering=:degrevlex)
         F = [x^2+1-3, x*y-z, x*z^2-3*y^2]
         # prime is bigger than 2^31, should throw an error
         @test_throws ErrorException AlgebraicSolving._convert_to_msolve(F)
-        R, (x,y,z) = polynomial_ring(GF(101),["x","y","z"], internal_ordering=:degrevlex)
+        R, (x,y,z) = polynomial_ring(_GF(101),["x","y","z"], internal_ordering=:degrevlex)
         F = [x^2+1-3, x*y-z, x*z^2-3*y^2]
+        @show F
         res = AlgebraicSolving._convert_to_msolve(F)
         @test AlgebraicSolving._convert_finite_field_array_to_abstract_algebra(Int32(3), res[1], res[2], res[3], R) == F
     end


### PR DESCRIPTION
Reverts algebraic-solving/AlgebraicSolving.jl#78.

Turns out that there needs to be more done when constructing multivariate polynomials than what this PR did. Fixing this leads to an interface to Nemo which will be slower than the `MPolyBuildCtx()` and `push_term!()` construction.