### PR TITLE
Make `Test` a test-only dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,13 @@ Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 msolve_jll = "6d01cc9a-e8f6-580e-8c54-544227e08205"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]
 
 [compat]
 LinearAlgebra = "1.6"

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -1,5 +1,4 @@
 using Markdown
-using Test
 using msolve_jll
 using Nemo
 using LinearAlgebra


### PR DESCRIPTION
and thus slightly reducing load times of AlgebraicSolving and all of its dependents.