### PR TITLE
Allow Nemo.jl 0.53

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraicSolving"
 uuid = "66b61cbe-0446-4d5d-9090-1ff510639f9d"
 authors = ["ederc <ederc@mathematik.uni-kl.de>", "Mohab Safey El Din <Mohab.Safey@lip6.fr", "Rafael Mohr <rafael.mohr@lip6.fr>", "Rémi Prebet <remi.prebet@ens-lyon.fr>"]
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -23,7 +23,7 @@ test = ["Test"]
 LinearAlgebra = "1.6"
 Logging = "1.6"
 Markdown = "1.6"
-Nemo = "0.43, 0.44, 0.45, 0.46, 0.47, 0.48, 0.49, 0.50, 0.51, 0.52"
+Nemo = "0.43, 0.44, 0.45, 0.46, 0.47, 0.48, 0.49, 0.50, 0.51, 0.52, 0.53"
 Printf = "1.6"
 Random = "1.6"
 StaticArrays = "1"


### PR DESCRIPTION
@ederc could you please tag a patch release with this? I already bumped the version number for your convenience. Thanks!

The Nemo release is mostly just breaking as some objects from FLINT are printed slightly differently; I think this is only about Arb values, so it should not be relevant for AlgebraicSolving.

IMO it would be good to release this separately from the planned msolve update, as this will make it easier to spot any issues etc. in Oscar.