### PR TITLE
Avoid some invalidations related to `Base.hash`

### DIFF
--- a/src/siggb/hashtable.jl
+++ b/src/siggb/hashtable.jl
@@ -159,7 +159,7 @@ end
 
 function insert_in_hash_table!(ht::MonomialHashtable{N}, e::Monomial{N}) where {N}
     # generate hash
-    he = Base.hash(e)
+    he = hash_monomial(e)
 
     # find new elem position in the table
     hidx = he
@@ -201,7 +201,7 @@ end
 
 function find_in_hash_table(ht::MonomialHashtable{N}, e::Monomial{N}) where {N}
     # generate hash
-    he = Base.hash(e)
+    he = hash_monomial(e)
 
     # find new elem position in the table
     hidx = he
@@ -278,7 +278,7 @@ function fill_divmask!(ht::MonomialHashtable{N}) where N
     @inbounds for vidx in 1:ht.load
         m = ht.exponents[vidx]
         divm = divmask(m, ht.divmap, ht.ndivbits)
-        hsh = Base.hash(m)
+        hsh = hash_monomial(m)
         ht.hashdata[vidx] = Hashvalue(hsh, divm)
     end
 

--- a/src/siggb/module.jl
+++ b/src/siggb/module.jl
@@ -123,7 +123,7 @@ function construct_module_core(sig::Sig{N},
             res_mod_mns[i] = rewr_mod_mns[i]
         end
     else
-        hsh = Base.hash(mult)
+        hsh = hash_monomial(mult)
         check_enlarge_hashtable!(basis_ht, plength)
         insert_multiplied_poly_in_hash_table!(res_mod_mns, hsh, mult,
                                               rewr_mod_mns,

--- a/src/siggb/monomials.jl
+++ b/src/siggb/monomials.jl
@@ -134,16 +134,18 @@ function divmask(e::Monomial{N},
     res
 end
 
-@generated function makehash(::Val{N}, m) where {N}
+@generated function makehash(::Val{N}, m, h::UInt) where {N}
     rng = MersenneTwister(18121987)
-    hash = :( $(UInt64(0)) )
+    hash = :(h)
     for i in 1:N
         hash = :($hash + $(rand(rng, MonHash))*(m[$i]))
     end
     return :($hash % MonHash)
 end
 
-Base.hash(a::Monomial{N}) where N = makehash(Val(N), a.exps)
+hash_monomial(a::Monomial{N}, h::UInt) where N = makehash(Val(N), a.exps, h)
+hash_monomial(a::Monomial{N}) where N = hash_monomial(a, zero(UInt))
+Base.hash(a::Monomial{N}, h::UInt) where N = UInt(hash_monomial(a, h))
 
 function leading_monomial(basis::Basis,
                           basis_ht::MonomialHashtable,

--- a/src/siggb/symbolic_pp.jl
+++ b/src/siggb/symbolic_pp.jl
@@ -385,7 +385,7 @@ function write_to_matrix_row!(matrix::MacaulayMatrix,
                               sig::Sig,
                               row_ind=matrix.nrows+1)
 
-    hsh = Base.hash(mult)
+    hsh = hash_monomial(mult)
     poly = basis.monomials[basis_idx]
     row = similar(basis.monomials[basis_idx])
     check_enlarge_hashtable!(symbol_ht, length(basis.monomials[basis_idx]))


### PR DESCRIPTION
According to [the julia docs](https://docs.julialang.org/en/v1/base/base/#Base.hash), new types should implement the 2-argument version of `hash`, as this allows for composeability of hashing and there exists a generic delegation from the 1-arg to the 2-arg version in julia base. Not adhering to this leads to a bunch of invalidations, i.e. basically all methods that uses `Base.hash` in their body need to be re-compiled once this method from AlgebraicSolving is loaded (cf. https://github.com/oscar-system/Oscar.jl/issues/2525).

Furthermore, the julia docs state that `Base.hash` should always return a `UInt` (i.e. a 64-bit unsigned int on most systems). I added compliance with that by splitting the function into one named `Base.hash` that returns a `UInt`, and one named `hash_monomial` that returns a `MonHash` (aka UInt32).

cc @fingolfin 