### PR TITLE
Allow Gröbner basis computation with inputs in msolve format

### DIFF
--- a/src/algorithms/groebner-bases.jl
+++ b/src/algorithms/groebner-bases.jl
@@ -134,6 +134,96 @@ function groebner_basis(
     end
 end
 
+@doc Markdown.doc"""
+    _core_groebner_basis_array(lens::Vector{Int32}, cfs::Union{Vector{Int32},Vector{BigInt}}, exps::Vector{Int32}, field_char::Int, <keyword arguments>)
+
+Compute a Gröbner basis of the ideal defined by the input data w.r.t. to the degree reverse lexicographical monomial ordering using Faugère's F4 algorithm.
+
+**Note**: Both the input and output of this function are given as flattened arrays of integers instead of polynomials.
+
+# Arguments
+- `lens::Vector{Int32}`: vector of number of terms per generator.
+- `cfs::Union{Vector{Int32},Vector{BigInt}}`: vector of coefficients of all generators, concatenated. When working over the rationals, the coefficients are given as pairs of numerators and denominators, i.e. `cfs[2*i-1]` is the numerator and `cfs[2*i]` the denominator of the `i`-th coefficient.
+- `exps::Vector{Int32}`: vector of exponent vectors of all generators, concatenated.
+- `field_char::Int`: characteristic of the ground field, `0` for the rationals.
+- `initial_hts::Int=17`: initial hash table size `log_2`.
+- `nr_thrds::Int=1`: number of threads for parallel linear algebra.
+- `max_nr_pairs::Int=0`: maximal number of pairs per matrix, only bounded by minimal degree if `0`.
+- `la_option::Int=2`: linear algebra option: exact sparse-dense (`1`), exact sparse (`2`, default), probabilistic sparse-dense (`42`), probabilistic sparse(`44`).
+- `eliminate::Int=0`: size of first block of variables to be eliminated.
+- `complete_reduction::Bool=true`: compute a reduced Gröbner basis for `I`.
+- `truncate_lifting::Int=0`: truncates the lifting process to given number of elements, only applicable when working over the rationals.
+- `info_level::Int=0`: info level printout: off (`0`, default), summary (`1`), detailed (`2`).
+```
+
+**Note**: This is an internal function.
+"""
+function _core_groebner_basis_array(
+    lens::Vector{Int32},
+    cfs::Union{Vector{Int32},Vector{BigInt}},
+    exps::Vector{Int32},
+    field_char::Int;
+    initial_hts::Int=17,
+    nr_thrds::Int=1,
+    max_nr_pairs::Int=0,
+    la_option::Int=2,
+    eliminate::Int=0,
+    complete_reduction::Bool=true,
+    truncate_lifting::Int=0,
+    info_level::Int=0
+)::Tuple{Vector{Int32},Union{Vector{Int32},Vector{BigInt}},Vector{Int32}}
+    nr_gens = length(lens)
+    nr_vars = length(exps) ÷ sum(lens)
+
+    mon_order = 0
+    elim_block_size = eliminate
+    reduce_gb = Int(complete_reduction)
+
+    gb_ld = Ref(Cint(0))
+    gb_len = Ref(Ptr{Cint}(0))
+    gb_exp = Ref(Ptr{Cint}(0))
+    gb_cf = Ref(Ptr{Cvoid}(0))
+
+    if field_char == 0
+        nr_terms = ccall((:export_groebner_qq, libmsolve), Int,
+            (Ptr{Nothing}, Ptr{Cint}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cvoid}},
+                Ptr{Cint}, Ptr{Cint}, Ptr{Cvoid}, Cint, Cint, Cint, Cint, Cint, Cint,
+                Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cint),
+            cglobal(:jl_malloc), gb_ld, gb_len, gb_exp, gb_cf, lens, exps, cfs,
+            field_char, mon_order, elim_block_size, nr_vars, nr_gens, initial_hts,
+            nr_thrds, max_nr_pairs, 0, la_option, reduce_gb, 0, truncate_lifting, info_level)
+    else
+        nr_terms = ccall((:export_f4, libneogb), Int,
+            (Ptr{Nothing}, Ptr{Cint}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cvoid}},
+                Ptr{Cint}, Ptr{Cint}, Ptr{Cvoid}, Cint, Cint, Cint, Cint, Cint, Cint,
+                Cint, Cint, Cint, Cint, Cint, Cint, Cint),
+            cglobal(:jl_malloc), gb_ld, gb_len, gb_exp, gb_cf, lens, exps, cfs,
+            field_char, mon_order, elim_block_size, nr_vars, nr_gens, initial_hts,
+            nr_thrds, max_nr_pairs, 0, la_option, reduce_gb, 0, info_level)
+    end
+
+    # convert to julia array, also give memory management to julia
+    jl_ld = gb_ld[]
+    jl_len = Int32.(Base.unsafe_wrap(Array, gb_len[], jl_ld))
+    jl_exp = Int32.(Base.unsafe_wrap(Array, gb_exp[], nr_terms * nr_vars))
+
+    # coefficient handling depending on field characteristic
+    if field_char == 0
+        ptr = reinterpret(Ptr{BigInt}, gb_cf[])
+        jl_cf = BigInt.([deepcopy(unsafe_load(ptr, i)) for i in 1:nr_terms])
+    else
+        ptr = reinterpret(Ptr{Int32}, gb_cf[])
+        jl_cf = Int32.(Base.unsafe_wrap(Array, ptr, nr_terms))
+    end
+
+    ccall((:free_f4_julia_result_data, libneogb), Nothing,
+        (Ptr{Nothing}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cint}},
+            Ptr{Ptr{Cvoid}}, Int, Int),
+        cglobal(:jl_free), gb_len, gb_exp, gb_cf, jl_ld, field_char)
+
+    return jl_len, jl_cf, jl_exp
+end
+
 function _core_groebner_basis(
         I::Ideal{T} where T <: MPolyRingElem;
         initial_hts::Int=17,
@@ -181,47 +271,24 @@ function _core_groebner_basis(
         I.gb[eliminate] = F
         return I.gb[eliminate]
     end
-    gb_ld  = Ref(Cint(0))
-    gb_len = Ref(Ptr{Cint}(0))
-    gb_exp = Ref(Ptr{Cint}(0))
-    gb_cf  = Ref(Ptr{Cvoid}(0))
 
-    if field_char == 0
-        nr_terms  = ccall((:export_groebner_qq, libmsolve), Int,
-            (Ptr{Nothing}, Ptr{Cint}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cvoid}},
-            Ptr{Cint}, Ptr{Cint}, Ptr{Cvoid}, Cint, Cint, Cint, Cint, Cint, Cint,
-            Cint, Cint, Cint, Cint, Cint, Cint, Cint, Cint),
-            cglobal(:jl_malloc), gb_ld, gb_len, gb_exp, gb_cf, lens, exps, cfs,
-            field_char, mon_order, elim_block_size, nr_vars, nr_gens, initial_hts,
-            nr_thrds, max_nr_pairs, 0, la_option, reduce_gb, 0, truncate_lifting, info_level)
+    jl_len, jl_cf, jl_exp = _core_groebner_basis_array(
+        lens, cfs, exps, field_char;
+        initial_hts=initial_hts, nr_thrds=nr_thrds,
+        max_nr_pairs=max_nr_pairs, la_option=la_option, eliminate=eliminate,
+        complete_reduction=complete_reduction, truncate_lifting=truncate_lifting,
+        info_level=info_level)
 
-    else
-        nr_terms  = ccall((:export_f4, libneogb), Int,
-            (Ptr{Nothing}, Ptr{Cint}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cvoid}},
-            Ptr{Cint}, Ptr{Cint}, Ptr{Cvoid}, Cint, Cint, Cint, Cint, Cint, Cint,
-            Cint, Cint, Cint, Cint, Cint, Cint, Cint),
-            cglobal(:jl_malloc), gb_ld, gb_len, gb_exp, gb_cf, lens, exps, cfs,
-            field_char, mon_order, elim_block_size, nr_vars, nr_gens, initial_hts,
-            nr_thrds, max_nr_pairs, 0, la_option, reduce_gb, 0, info_level)
-    end
+    jl_ld = Int32(length(jl_len))
+    nr_terms = length(jl_exp) ÷ nr_vars
 
     if nr_terms == 0
         I.gb[eliminate] = [R(0)]
         return I.gb[eliminate]
     end
 
-    # convert to julia array, also give memory management to julia
-    jl_ld   = gb_ld[]
-    jl_len  = Base.unsafe_wrap(Array, gb_len[], jl_ld)
-    jl_exp  = Base.unsafe_wrap(Array, gb_exp[], nr_terms*nr_vars)
-
-    #  coefficient handling depending on field characteristic
     if field_char == 0
-        ptr     = reinterpret(Ptr{BigInt}, gb_cf[])
-        jl_cf   = QQFieldElem[QQFieldElem(unsafe_load(ptr, i)) for i in 1:nr_terms]
-    else
-        ptr     = reinterpret(Ptr{Int32}, gb_cf[])
-        jl_cf   = Base.unsafe_wrap(Array, ptr, nr_terms)
+        jl_cf = QQ.(jl_cf)
     end
 
     #  shall eliminated variables be removed?
@@ -237,10 +304,6 @@ function _core_groebner_basis(
         basis = _convert_finite_field_array_to_abstract_algebra(
             jl_ld, jl_len, jl_cf, jl_exp, R, eliminate)
     end
-    ccall((:free_f4_julia_result_data, libneogb), Nothing ,
-          (Ptr{Nothing}, Ptr{Ptr{Cint}}, Ptr{Ptr{Cint}},
-           Ptr{Ptr{Cvoid}}, Int, Int),
-          cglobal(:jl_free), gb_len, gb_exp, gb_cf, jl_ld, field_char)
 
     I.gb[eliminate] = basis
     return I.gb[eliminate]

--- a/test/algorithms/groebner-bases.jl
+++ b/test/algorithms/groebner-bases.jl
@@ -103,7 +103,65 @@
         R(1)
     ]
     @test G == H
-	
+end
+
+@testset "Algorithms -> Gröbner bases (array interface)" begin
+    # Test 1: finite field
+    field_char = 101
+    # we represent [x+2*y+2*z-1, x^2+2*y^2+2*z^2-x, 2*x*y+2*y*z-y] in msolve format
+    lens = Int32[4, 4, 3]
+    cfs = Int32[
+        1, 2, 2, 100, # 1, 2, 2, -1
+        1, 2, 2, 100, # 1, 2, 2, -1
+        2, 2, 100 # 2, 2, -1
+    ]
+    exps = Int32[
+        1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, # x, y, z, 1
+        2, 0, 0, 0, 2, 0, 0, 0, 2, 1, 0, 0, # x^2, y^2, z^2, x
+        1, 1, 0, 0, 1, 1, 0, 1, 0 # x*y, y*z, y
+    ]
+    # the expected GB is [x+2*y+2*z+100, y*z+82*z^2+10*y+40*z, y^2+60*z^2+20*y+81*z, z^3+28*z^2+64*y+13*z]
+    # we also represent it in msolve format
+    gb_lens = Int32[4, 4, 4, 4]
+    gb_cfs = Int32[
+        1, 2, 2, 100,
+        1, 82, 10, 40,
+        1, 60, 20, 81,
+        1, 28, 64, 13
+    ]
+    gb_exps = Int32[
+        1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, # x, y, z, 1
+        0, 1, 1, 0, 0, 2, 0, 1, 0, 0, 0, 1, # y*z, z^2, y, z
+        0, 2, 0, 0, 0, 2, 0, 1, 0, 0, 0, 1, # y^2, z^2, y, z
+        0, 0, 3, 0, 0, 2, 0, 1, 0, 0, 0, 1 # z^3, z^2, y, z
+    ]
+    @test (gb_lens, gb_cfs, gb_exps) == AlgebraicSolving._core_groebner_basis_array(lens, cfs, exps, field_char)
+
+    # Test 2: rational field
+    field_char = 0
+    # we represent [x+2*y+2*z-1, x^2+2*y^2+2*z^2-x, 2*x*y+2*y*z-y] in msolve format
+    # lens and exps are the same as Test 1
+    cfs = BigInt[
+        1, 1, 2, 1, 2, 1, -1, 1, # 1/1, 2/1, 2/1, -1/1
+        1, 1, 2, 1, 2, 1, -1, 1, # 1/1, 2/1, 2/1, -1/1
+        2, 1, 2, 1, -1, 1 # 2/1, 2/1, -1/1
+    ]
+    # the expected GB is [x+2*y+2*z-1, 10*y*z+12*z^2-y-4*z, 5*y^2-3*z^2-y+z, 210*z^3-79*z^2+7*y+3*z]
+    # we represent the expected GB in msolve format
+    gb_lens = Int32[4, 4, 4, 4]
+    gb_cfs = BigInt[
+        1, 2, 2, -1,
+        10, 12, -1, -4,
+        5, -3, -1, 1,
+        210, -79, 7, 3
+    ]
+    gb_exps = Int32[
+        1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, # x, y, z, 1
+        0, 1, 1, 0, 0, 2, 0, 1, 0, 0, 0, 1, # y*z, z^2, y, z
+        0, 2, 0, 0, 0, 2, 0, 1, 0, 0, 0, 1, # y^2, z^2, y, z
+        0, 0, 3, 0, 0, 2, 0, 1, 0, 0, 0, 1 # z^3, z^2, y, z
+    ]
+    @test (gb_lens, gb_cfs, gb_exps) == AlgebraicSolving._core_groebner_basis_array(lens, cfs, exps, field_char)
 end
 
 @testset "Algorithms -> Sig Gröbner bases" begin


### PR DESCRIPTION
This PR adds `_core_groebner_basis_array` to allow Gröbner basis computation with inputs in msolve format rather than of AbstractAlgebra.jl types. Since the msolve format relies exclusively on built-in types of Julia, the resulting data can be passed easily between processes.