### PR TITLE
Allow parallel Gröbner basis computations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["ederc <ederc@mathematik.uni-kl.de>", "Mohab Safey El Din <Mohab.Safe
 version = "0.10.4"
 
 [deps]
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
@@ -20,6 +21,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["Test"]
 
 [compat]
+Distributed = "1.6"
 LinearAlgebra = "1.6"
 Logging = "1.6"
 Markdown = "1.6"

--- a/src/algorithms/groebner-bases.jl
+++ b/src/algorithms/groebner-bases.jl
@@ -24,6 +24,7 @@ At the moment the underlying algorithm is based on variants of Faugère's F4 Alg
 - `complete_reduction::Bool=true`: compute a reduced Gröbner basis for `I`.
 - `normalize::Bool=false`: normalize generators of Gröbner basis for `I`, only applicable when working over the rationals.
 - `truncate_lifting::Int=0`: truncates the lifting process to given number of elements, only applicable when working over the rationals.
+- `worker_pool::Union{Nothing,AbstractWorkerPool}=nothing`: run the Gröbner basis computation on a worker from the given pool, if not `nothing`.
 - `info_level::Int=0`: info level printout: off (`0`, default), summary (`1`), detailed (`2`).
 
 # Examples
@@ -52,6 +53,7 @@ function eliminate(
         complete_reduction::Bool=true,
         normalize::Bool=false,
         truncate_lifting::Int=0,
+        worker_pool::Union{Nothing,AbstractWorkerPool}=nothing,
         info_level::Int=0
         )
     if eliminate <= 0
@@ -63,6 +65,7 @@ function eliminate(
                               complete_reduction=complete_reduction,
                               normalize = normalize,
                               truncate_lifting = truncate_lifting,
+                              worker_pool = worker_pool,
                               info_level=info_level)
     end
 end
@@ -86,6 +89,7 @@ At the moment the underlying algorithm is based on variants of Faugère's F4 Alg
 - `complete_reduction::Bool=true`: compute a reduced Gröbner basis for `I`.
 - `normalize::Bool=false`: normalize generators of Gröbner basis for `I`, only applicable when working over the rationals.
 - `truncate_lifting::Int=0`: truncates the lifting process to given number of elements, only applicable when working over the rationals.
+- `worker_pool::Union{Nothing,AbstractWorkerPool}=nothing`: if not `nothing`, run the core Gröbner-basis array computation on a worker from this pool.
 - `info_level::Int=0`: info level printout: off (`0`, default), summary (`1`), detailed (`2`).
 
 # Examples
@@ -121,6 +125,7 @@ function groebner_basis(
         complete_reduction::Bool=true,
         normalize::Bool=false,
         truncate_lifting::Int=0,
+        worker_pool::Union{Nothing,AbstractWorkerPool}=nothing,
         info_level::Int=0
         )
     return get!(I.gb, eliminate) do
@@ -130,6 +135,7 @@ function groebner_basis(
                              complete_reduction = complete_reduction,
                              normalize = normalize,
                              truncate_lifting = truncate_lifting,
+                             worker_pool = worker_pool,
                              info_level = info_level)
     end
 end
@@ -235,6 +241,7 @@ function _core_groebner_basis(
         complete_reduction::Bool=true,
         normalize::Bool=false,
         truncate_lifting::Int=0,
+        worker_pool::Union{Nothing,AbstractWorkerPool}=nothing,
         info_level::Int=0
         )
     F = I.gens
@@ -272,12 +279,18 @@ function _core_groebner_basis(
         return I.gb[eliminate]
     end
 
-    jl_len, jl_cf, jl_exp = _core_groebner_basis_array(
+    run_core_array = () -> _core_groebner_basis_array(
         lens, cfs, exps, field_char;
         initial_hts=initial_hts, nr_thrds=nr_thrds,
         max_nr_pairs=max_nr_pairs, la_option=la_option, eliminate=eliminate,
         complete_reduction=complete_reduction, truncate_lifting=truncate_lifting,
         info_level=info_level)
+
+    jl_len, jl_cf, jl_exp = if isnothing(worker_pool)
+        run_core_array()
+    else
+        remotecall_fetch(run_core_array, worker_pool)
+    end
 
     jl_ld = Int32(length(jl_len))
     nr_terms = length(jl_exp) ÷ nr_vars

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -7,6 +7,7 @@ using StaticArrays
 import Random: MersenneTwister
 import Logging: ConsoleLogger, with_logger, Warn, Info
 import Printf: @sprintf, @printf
+import Distributed: AbstractWorkerPool, remotecall_fetch
 
 import Nemo:
     bell,

--- a/test/algorithms/groebner-bases.jl
+++ b/test/algorithms/groebner-bases.jl
@@ -1,3 +1,5 @@
+using Distributed
+
 @testset "Algorithms -> Gröbner bases" begin
     R, (x,y,z) = polynomial_ring(GF(101),["x","y","z"], internal_ordering=:degrevlex)
     I = Ideal([x+2*y+2*z-1, x^2+2*y^2+2*z^2-x, 2*x*y+2*y*z-y])
@@ -162,6 +164,54 @@ end
         0, 0, 3, 0, 0, 2, 0, 1, 0, 0, 0, 1 # z^3, z^2, y, z
     ]
     @test (gb_lens, gb_cfs, gb_exps) == AlgebraicSolving._core_groebner_basis_array(lens, cfs, exps, field_char)
+end
+
+@testset "Algorithms -> Gröbner bases with workers" begin
+    _, (x, y, z) = polynomial_ring(GF(101), ["x", "y", "z"], internal_ordering=:degrevlex)
+    F1 = [x + 2 * y + 2 * z - 1, x^2 + 2 * y^2 + 2 * z^2 - x, 2 * x * y + 2 * y * z - y]
+    H1 = MPolyRingElem[
+        x + 2 * y + 2 * z + 100
+        y * z + 82 * z^2 + 10 * y + 40 * z
+        y^2 + 60 * z^2 + 20 * y + 81 * z
+        z^3 + 28 * z^2 + 64 * y + 13 * z
+    ]
+
+    _, (x1, x2) = polynomial_ring(QQ, ["x1", "x2"])
+    F2 = [3 * x1^2 + ZZ(2)^100, 2 * x1 * x2 + 5 * x1 + ZZ(2)^100]
+    H2 = MPolyRingElem[
+        3 * x1 - 2 * x2 - 5
+        4 * x2^2 + 20 * x2 + 3802951800684688204490109616153
+    ]
+
+    _, (x, y, z) = polynomial_ring(GF(17), ["x", "y", "z"], internal_ordering=:degrevlex)
+    F3 = [x^2 + 1 - 3, x * y - z, x * z^2 - 3 * y^2]
+    H3 = MPolyRingElem[
+        z^2
+        y * z
+        x * z + 15 * y
+        y^2
+        x * y + 16 * z
+        x^2 + 15
+    ]
+
+    nb_tests = 42
+    F = [F1, F2, F3]
+    G = Vector{Vector{MPolyRingElem}}(undef, nb_tests)
+    H = [H1, H2, H3]
+
+    nb_workers = 2
+    worker_ids = addprocs(nb_workers; exeflags="--project=$(Base.active_project())")
+    @everywhere worker_ids using AlgebraicSolving
+    worker_pool = WorkerPool(worker_ids)
+
+    Threads.@threads for i in 1:nb_tests
+        G[i] = groebner_basis(Ideal(F[i%3+1]), worker_pool=worker_pool)
+    end
+    for i in 1:nb_tests
+        @test G[i] == H[i%3+1]
+    end
+
+    rmprocs(worker_ids)
 end
 
 @testset "Algorithms -> Sig Gröbner bases" begin


### PR DESCRIPTION
This PR provides a mitigation of issue #111, by allowing Gröbner basis computations to be done in parallel on different workers. As this PR is based on #127, it should be merged after that PR.

A proper fix for #111 will require work on msolve; However, this will likely require major interface changes (see https://github.com/algebraic-solving/msolve/issues/288), so we cannot expect a new version of msolve that fixes the problem to be available very soon.