### PR TITLE
Fix bug in Gröbner basis caching

### DIFF
--- a/src/algorithms/groebner-bases.jl
+++ b/src/algorithms/groebner-bases.jl
@@ -128,7 +128,12 @@ function groebner_basis(
         worker_pool::Union{Nothing,AbstractWorkerPool}=nothing,
         info_level::Int=0
         )
-    return get!(I.gb, eliminate) do
+    key = if intersect && complete_reduction && !normalize && truncate_lifting == 0
+        eliminate
+    else
+        reinterpret(Int64, hash((eliminate, intersect, complete_reduction, normalize, truncate_lifting)) | 0x8000000000000000)
+    end
+    return get!(I.gb, key) do
         _core_groebner_basis(I, initial_hts = initial_hts, nr_thrds = nr_thrds,
                              max_nr_pairs = max_nr_pairs, la_option = la_option,
                              eliminate = eliminate, intersect = intersect,

--- a/test/algorithms/groebner-bases.jl
+++ b/test/algorithms/groebner-bases.jl
@@ -30,6 +30,9 @@ using Distributed
 
     @test_throws ErrorException eliminate(I,0)
     L = eliminate(I,2)
+    H = MPolyRingElem[
+        z^4 + 38*z^3 + 95*z^2 + 95*z
+    ]
     @test L == H
     @test I.gb[2] == H
 


### PR DESCRIPTION
In the following test:

https://github.com/algebraic-solving/AlgebraicSolving.jl/blob/f22e33498f203aab3f97ceecef80518c63e9940a/test/algorithms/groebner-bases.jl#L22-L34

Line 23 and Line 32 unexpectedly give the same results due to #135. This PR fixes the issue while maintaining maximum compatibility, by using truncated hashes as negative Int64 dictionary keys.

Closes #135.