### PR TITLE
Fix a multithreading bug in Newton interpolation

### DIFF
--- a/src/interp/newton.jl
+++ b/src/interp/newton.jl
@@ -185,6 +185,9 @@ function newton(
         end
     end
     populate(Vector{ZZRingElem}(), 1; num_threads=nr_thrds)
+    perm = sortperm(x)
+    x = x[perm]
+    y = y[perm]
     f = newton(R, x, y, d)
     finish!(prog)
     return f


### PR DESCRIPTION
When the input blackbox `bb` can be run in parallel, the order of `x` and `y` generated by `populate` is not guaranteed. This PR fixes the issue by sorting both `x` and `y` after data generation, as in `cuyt_lee_shifted`:

https://github.com/algebraic-solving/AlgebraicSolving.jl/blob/2520e64b02671230ef03ef0f90500e6060ba47b8/src/interp/cuyt_lee.jl#L167-L170