### PR TITLE
Update Documenter to 1.17

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,4 +7,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
 
 [compat]
-Documenter = "0.26"
+Documenter = "1.17.0"


### PR DESCRIPTION
I encountered some world-age warnings when rebuilding the docs. The underlying issue has been fixed in Documenter 1.8.1 ([changelog](https://documenter.juliadocs.org/stable/release-notes/#Version-[v1.8.1](https://github.com/JuliaDocs/Documenter.jl/releases/tag/v1.8.1)-2025-02-11)), but why not just bump to the latest version?