### PR TITLE
Choose verification point more carefully in Thiele's interpolation

### DIFF
--- a/src/interp/thiele.jl
+++ b/src/interp/thiele.jl
@@ -132,8 +132,18 @@ function thiele(
     end
     # We verify that the interpolating formula is correct
     # for an additional point.
-    xᵢ = xᵢ + 1
-    if evaluate(f, xᵢ) != bb(xᵢ)
+    while true
+        xᵢ = xᵢ + 1
+        if !iszero(evaluate(denominator(f), xᵢ))
+            break
+        end
+    end
+    yᵢ = try
+        bb(xᵢ)
+    catch _
+        throw(ThieleError("Verification failed."))
+    end
+    if evaluate(f, xᵢ) != yᵢ
         throw(ThieleError("Verification failed."))
     end
     return f


### PR DESCRIPTION
During the verification phase of Thiele's interpolation, we do not guarantee beforehand whether the blackbox `bb` or the predicted rational function `f` is well-defined at the verification point.

This PR makes the program choose the verification point where `f` is guaranteed to be well-defined; on that point, we then check whether `bb` is well-defined and equal to `f`.